### PR TITLE
FIX: Using deprecated API

### DIFF
--- a/spacetrack/base.py
+++ b/spacetrack/base.py
@@ -6,7 +6,11 @@ import re
 import threading
 import time
 import weakref
-from collections import Mapping, OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+from collections import OrderedDict
 from functools import partial
 
 import requests

--- a/spacetrack/operators.py
+++ b/spacetrack/operators.py
@@ -2,7 +2,10 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 import six
 


### PR DESCRIPTION
Currently, `Mapping` and `Sequence` are imported from the `collections` module. In Python 3.8 and beyond, they (supposedly) need to be imported from `collections.abc` instead. This pull request uses a conditional import to use the newer API but also to provide backwards-compatibility for older versions of Python.