### PR TITLE
Added async before with to make code executable

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,7 +87,7 @@ The same example is shown below synchronously and asynchronously.
         st = AsyncSpaceTrackClient(identity='user@example.com',
                                    password='password')
 
-        with st:
+        async with st:
             data = await st.tle_latest(
                 iter_lines=True, ordinal=1, epoch='>now-30',
                 mean_motion=op.inclusive_range(0.99, 1.01),


### PR DESCRIPTION
Hi!

Thank you for providing spacetrack! I tried one code snippet for asynchronous access to space-track and found out that it didn't work. Was easy to fix by simply adding "async" before "with st:"

Regards,
rzbrk