### PR TITLE
Add additional_rate_limit argument

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Change Log
 Unreleased_
 -----------
 
+Added
+~~~~~
+
+- ``additional_rate_limit`` argument to
+  :class:`~spacetrack.base.SpaceTrackClient`.
+
 Fixed
 ~~~~~
 

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -37,6 +37,7 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
         rush_store=None,
         rush_key_prefix="",
         httpx_client=None,
+        additional_rate_limit=None,
     ):
         if httpx_client is None:
             httpx_client = httpx.AsyncClient()
@@ -49,6 +50,7 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             rush_store=rush_store,
             rush_key_prefix=rush_key_prefix,
             httpx_client=httpx_client,
+            additional_rate_limit=additional_rate_limit,
         )
 
     async def _handle_event(self, event):


### PR DESCRIPTION
Resolves #73

This would allow the following pattern

```python
from rush.quota import Quota

st = SpaceTrackClient(..., additional_rate_limit=Quota.per_hour(200))
```