### PR TITLE
Fix rate limit callback waits and support the predicate cache on trio

### DIFF
--- a/newsfragments/160.changed.2.rst
+++ b/newsfragments/160.changed.2.rst
@@ -1,0 +1,2 @@
+Predicate caching for keyword validation now works when using :class:`~spacetrack.aio.AsyncSpaceTrackClient` with trio.
+Previously, the on-disk cache was skipped because the file locking implementation only supported asyncio.

--- a/newsfragments/160.changed.3.rst
+++ b/newsfragments/160.changed.3.rst
@@ -1,0 +1,1 @@
+:class:`~spacetrack.aio.AsyncSpaceTrackClient` no longer performs blocking cache file reads and writes on the event loop; they now run in a worker thread.

--- a/newsfragments/160.changed.rst
+++ b/newsfragments/160.changed.rst
@@ -1,0 +1,2 @@
+Rate limit waits now guarantee that the ``callback`` has finished before the request is retried, in all clients.
+As a result, an exception raised by an async callback now propagates as an :class:`ExceptionGroup` on asyncio instead of being silently discarded, matching the existing trio behaviour.

--- a/newsfragments/160.changed.rst
+++ b/newsfragments/160.changed.rst
@@ -1,2 +1,2 @@
 Rate limit waits now guarantee that the ``callback`` has finished before the request is retried, in all clients.
-As a result, an exception raised by an async callback now propagates as an :class:`ExceptionGroup` on asyncio instead of being silently discarded, matching the existing trio behaviour.
+As a result, an exception raised by the callback now propagates instead of being silently discarded: directly in :class:`~spacetrack.base.SpaceTrackClient`, and as an :class:`ExceptionGroup` on asyncio, matching the existing trio behaviour.

--- a/newsfragments/160.fixed.rst
+++ b/newsfragments/160.fixed.rst
@@ -1,0 +1,1 @@
+:class:`~spacetrack.aio.AsyncSpaceTrackClient` now accepts a plain function as the rate limit ``callback``, as shown in the documentation, in addition to a coroutine function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.15",
 ]
 dependencies = [
+    "anyio>=4.10",
     "filelock>=3.17.0",
     "httpx2>=2.9.1",
     "logbook>=1.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "python-dateutil>=2.9.0.post0; python_version < '3.11'",
     "represent>=2.1",
     "rush>=2021.4.0",
-    "sniffio>=1.3.1",
 ]
 
 [project.urls]

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -1,3 +1,4 @@
+import inspect
 import time
 import weakref
 from functools import partial
@@ -255,7 +256,9 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
         logger.info("Rate limit reached. Sleeping for {:d} seconds.", duration)
 
         if self.callback is not None:
-            await self.callback(until)
+            result = self.callback(until)
+            if inspect.isawaitable(result):
+                await result
 
     async def _ratelimit_wait(self, duration):
         until = time.monotonic() + duration

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -1,11 +1,11 @@
 import time
 import weakref
+from functools import partial
 
 import anyio
 import httpx2
 import outcome
-import sniffio
-from filelock import AsyncFileLock
+from filelock import Timeout
 from httpx2 import USE_CLIENT_DEFAULT
 
 from .base import (
@@ -19,7 +19,6 @@ from .base import (
     ReadResponse,
     ReleaseLock,
     SpaceTrackClient,
-    UnsupportedAsyncLibrary,
     logger,
 )
 
@@ -38,7 +37,6 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
     be an ``httpx2.AsyncClient``.
     """
 
-    _file_lock_cls = AsyncFileLock
     _httpx_client_cls = httpx2.AsyncClient
 
     def __init__(
@@ -90,14 +88,20 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
         elif isinstance(event, RateLimitWait):
             await self._ratelimit_wait(event.duration)
         elif isinstance(event, AcquireLock):
-            if (
-                isinstance(event.lock, AsyncFileLock)
-                and sniffio.current_async_library() != "asyncio"
-            ):
-                raise UnsupportedAsyncLibrary
-            await event.lock.acquire()
+            # Mirror filelock's AsyncFileLock structure with backend-agnostic
+            # primitives: non-blocking acquire attempts in a worker thread,
+            # with a cancellable sleep between attempts.
+            while True:
+                try:
+                    await anyio.to_thread.run_sync(
+                        partial(event.lock.acquire, blocking=False)
+                    )
+                except Timeout:
+                    await anyio.sleep(0.05)
+                else:
+                    break
         elif isinstance(event, ReleaseLock):
-            await event.lock.release()
+            await anyio.to_thread.run_sync(event.lock.release)
         else:
             raise RuntimeError(f"Unknown event type: {type(event)}")
 

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -1,7 +1,7 @@
-import asyncio
 import time
 import weakref
 
+import anyio
 import httpx2
 import outcome
 import sniffio
@@ -62,7 +62,6 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             additional_rate_limit=additional_rate_limit,
             cache_path=cache_path,
         )
-        self._ratelimit_tasks = set()
 
     def _setup_finalizer(self):
         self._finalizer = weakref.finalize(
@@ -243,26 +242,10 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             await self.callback(until)
 
     async def _ratelimit_wait(self, duration):
-        async_library = sniffio.current_async_library()
-        if async_library == "asyncio":
-            await self._ratelimit_wait_asyncio(duration)
-        elif async_library == "trio":
-            await self._ratelimit_wait_trio(duration)
-
-    async def _ratelimit_wait_asyncio(self, duration):
         until = time.monotonic() + duration
-        task = asyncio.create_task(self._ratelimit_callback(until))
-        self._ratelimit_tasks.add(task)
-        task.add_done_callback(self._ratelimit_tasks.discard)
-        await asyncio.sleep(duration)
-
-    async def _ratelimit_wait_trio(self, duration):
-        import trio
-
-        until = time.monotonic() + duration
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(self._ratelimit_callback, until)
-            nursery.start_soon(trio.sleep, duration)
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(self._ratelimit_callback, until)
+            tg.start_soon(anyio.sleep, duration)
 
     async def get_predicates(self, class_, controller=None):
         """Get full predicate information for given request class, and cache

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -91,18 +91,27 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
         elif isinstance(event, AcquireFileLock):
             # Mirror filelock's AsyncFileLock structure with backend-agnostic
             # primitives: non-blocking acquire attempts in a worker thread,
-            # with a cancellable sleep between attempts.
+            # with a cancellable sleep between attempts. Each attempt is
+            # shielded so that a cancellation cannot discard an acquired
+            # lock; cancellation is delivered at the sleep instead.
             while True:
-                try:
-                    await anyio.to_thread.run_sync(
-                        partial(event.lock.acquire, blocking=False)
-                    )
-                except Timeout:
-                    await anyio.sleep(0.05)
-                else:
+                with anyio.CancelScope(shield=True):
+                    try:
+                        await anyio.to_thread.run_sync(
+                            partial(event.lock.acquire, blocking=False)
+                        )
+                    except Timeout:
+                        acquired = False
+                    else:
+                        acquired = True
+                if acquired:
                     break
+                await anyio.sleep(0.05)
         elif isinstance(event, ReleaseFileLock):
-            await anyio.to_thread.run_sync(event.lock.release)
+            # Shielded so that a cancelled scope cannot skip the release and
+            # leak the lock.
+            with anyio.CancelScope(shield=True):
+                await anyio.to_thread.run_sync(event.lock.release)
         elif isinstance(event, RunBlocking):
             return await anyio.to_thread.run_sync(event.func)
         else:

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -10,14 +10,14 @@ from httpx2 import USE_CLIENT_DEFAULT
 
 from .base import (
     BASE_URL,
-    AcquireLock,
+    AcquireFileLock,
     Event,
     IterContent,
     IterLines,
     NormalRequest,
     RateLimitWait,
     ReadResponse,
-    ReleaseLock,
+    ReleaseFileLock,
     RunBlocking,
     SpaceTrackClient,
     logger,
@@ -88,7 +88,7 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             return _iter_content_generator(event.response, event.decode)
         elif isinstance(event, RateLimitWait):
             await self._ratelimit_wait(event.duration)
-        elif isinstance(event, AcquireLock):
+        elif isinstance(event, AcquireFileLock):
             # Mirror filelock's AsyncFileLock structure with backend-agnostic
             # primitives: non-blocking acquire attempts in a worker thread,
             # with a cancellable sleep between attempts.
@@ -101,7 +101,7 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
                     await anyio.sleep(0.05)
                 else:
                     break
-        elif isinstance(event, ReleaseLock):
+        elif isinstance(event, ReleaseFileLock):
             await anyio.to_thread.run_sync(event.lock.release)
         elif isinstance(event, RunBlocking):
             return await anyio.to_thread.run_sync(event.func)

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -18,6 +18,7 @@ from .base import (
     RateLimitWait,
     ReadResponse,
     ReleaseLock,
+    RunBlocking,
     SpaceTrackClient,
     logger,
 )
@@ -102,6 +103,8 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
                     break
         elif isinstance(event, ReleaseLock):
             await anyio.to_thread.run_sync(event.lock.release)
+        elif isinstance(event, RunBlocking):
+            return await anyio.to_thread.run_sync(event.func)
         else:
             raise RuntimeError(f"Unknown event type: {type(event)}")
 

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -109,12 +109,12 @@ class RateLimitWait(Event):
 
 
 @define
-class AcquireLock(Event):
+class AcquireFileLock(Event):
     lock: FileLock
 
 
 @define
-class ReleaseLock(Event):
+class ReleaseFileLock(Event):
     lock: FileLock
 
 
@@ -402,9 +402,9 @@ class SpaceTrackClient:
             return _iter_content_generator(event.response, event.decode)
         elif isinstance(event, RateLimitWait):
             self._ratelimit_wait(event.duration)
-        elif isinstance(event, AcquireLock):
+        elif isinstance(event, AcquireFileLock):
             event.lock.acquire()
-        elif isinstance(event, ReleaseLock):
+        elif isinstance(event, ReleaseFileLock):
             event.lock.release()
         elif isinstance(event, RunBlocking):
             return event.func()
@@ -883,7 +883,7 @@ class SpaceTrackClient:
                 # thread_local=False because the async client acquires and
                 # releases the lock from different worker threads.
                 lock = FileLock(lock_file, thread_local=False)
-                yield AcquireLock(lock)
+                yield AcquireFileLock(lock)
 
                 try:
                     predicates_data = yield RunBlocking(read_cache)
@@ -895,7 +895,7 @@ class SpaceTrackClient:
                             partial(self._write_cache_file, cache_file, predicates_data)
                         )
                 finally:
-                    yield ReleaseLock(lock)
+                    yield ReleaseFileLock(lock)
 
             predicate_objects = self._parse_predicates_data(predicates_data)
 

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -7,16 +7,17 @@ import time
 import warnings
 import weakref
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from json import JSONDecodeError
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 
-import attr
 import httpx2
 import outcome
+from attrs import define
 from filelock import FileLock
 from httpx2 import USE_CLIENT_DEFAULT
 from logbook import Logger
@@ -79,47 +80,47 @@ class Event:
     pass
 
 
-@attr.s(slots=True)
+@define
 class NormalRequest(Event):
-    request = attr.ib()
-    stream = attr.ib(default=False)
-    follow_redirects = attr.ib(default=False)
+    request: httpx2.Request
+    stream: bool = False
+    follow_redirects: bool = False
 
 
-@attr.s(slots=True)
+@define
 class ReadResponse(Event):
-    response = attr.ib()
+    response: httpx2.Response
 
 
-@attr.s(slots=True)
+@define
 class IterLines(Event):
-    response = attr.ib()
+    response: httpx2.Response
 
 
-@attr.s(slots=True)
+@define
 class IterContent(Event):
-    response = attr.ib()
-    decode = attr.ib()
+    response: httpx2.Response
+    decode: bool
 
 
-@attr.s(slots=True)
+@define
 class RateLimitWait(Event):
-    duration = attr.ib()
+    duration: float
 
 
-@attr.s(slots=True)
+@define
 class AcquireLock(Event):
-    lock = attr.ib()
+    lock: FileLock
 
 
-@attr.s(slots=True)
+@define
 class ReleaseLock(Event):
-    lock = attr.ib()
+    lock: FileLock
 
 
-@attr.s(slots=True)
+@define
 class RunBlocking(Event):
-    func = attr.ib()
+    func: Callable[[], Any]
 
 
 class Predicate(ReprHelperMixin):

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -783,6 +783,7 @@ class SpaceTrackClient:
         t.daemon = True
         t.start()
         time.sleep(duration)
+        t.join()
 
     def __getattr__(self, attr):
         if attr in self.request_controllers:

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -780,11 +780,20 @@ class SpaceTrackClient:
 
     def _ratelimit_wait(self, duration):
         until = time.monotonic() + duration
-        t = threading.Thread(target=self._ratelimit_callback, args=(until,))
+        callback_outcome = None
+
+        def run_callback():
+            nonlocal callback_outcome
+            callback_outcome = outcome.capture(self._ratelimit_callback, until)
+
+        t = threading.Thread(target=run_callback)
         t.daemon = True
         t.start()
         time.sleep(duration)
         t.join()
+        # Match the async client, where a callback exception propagates and
+        # aborts the request.
+        callback_outcome.unwrap()
 
     def __getattr__(self, attr):
         if attr in self.request_controllers:

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -117,6 +117,11 @@ class ReleaseLock(Event):
     lock = attr.ib()
 
 
+@attr.s(slots=True)
+class RunBlocking(Event):
+    func = attr.ib()
+
+
 class Predicate(ReprHelperMixin):
     """Hold Space-Track predicate information.
 
@@ -400,6 +405,8 @@ class SpaceTrackClient:
             event.lock.acquire()
         elif isinstance(event, ReleaseLock):
             event.lock.release()
+        elif isinstance(event, RunBlocking):
+            return event.func()
         else:
             raise RuntimeError(f"Unknown event type: {type(event)}")
 
@@ -861,12 +868,15 @@ class SpaceTrackClient:
             hasher.update(key.encode())
             hashkey = hasher.hexdigest()[:16]
             cache_file = self._cache_path / f"predicates-{hashkey}.json"
-            predicates_data = self._read_cache_file(
-                cache_file, PREDICATE_CACHE_EXPIRY_TIME
+            read_cache = partial(
+                self._read_cache_file, cache_file, PREDICATE_CACHE_EXPIRY_TIME
             )
+            predicates_data = yield RunBlocking(read_cache)
 
             if predicates_data is None:
-                self._cache_path.mkdir(parents=True, exist_ok=True)
+                yield RunBlocking(
+                    partial(self._cache_path.mkdir, parents=True, exist_ok=True)
+                )
 
                 lock_file = cache_file.with_name(cache_file.name + ".lock")
                 # thread_local=False because the async client acquires and
@@ -875,14 +885,14 @@ class SpaceTrackClient:
                 yield AcquireLock(lock)
 
                 try:
-                    predicates_data = self._read_cache_file(
-                        cache_file, PREDICATE_CACHE_EXPIRY_TIME
-                    )
+                    predicates_data = yield RunBlocking(read_cache)
                     if predicates_data is None:
                         predicates_data = yield from self._download_predicate_data_generator(
                             class_, controller
                         )
-                        self._write_cache_file(cache_file, predicates_data)
+                        yield RunBlocking(
+                            partial(self._write_cache_file, cache_file, predicates_data)
+                        )
                 finally:
                     yield ReleaseLock(lock)
 

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -117,12 +117,6 @@ class ReleaseLock(Event):
     lock = attr.ib()
 
 
-class UnsupportedAsyncLibrary(Exception):
-    """Raised internally when an event cannot be handled with the active async
-    library.
-    """
-
-
 class Predicate(ReprHelperMixin):
     """Hold Space-Track predicate information.
 
@@ -299,7 +293,6 @@ class SpaceTrackClient:
         Predicate("favorites", "str"),
     }
 
-    _file_lock_cls = FileLock
     _httpx_client_cls = httpx2.Client
 
     def __init__(
@@ -876,33 +869,22 @@ class SpaceTrackClient:
                 self._cache_path.mkdir(parents=True, exist_ok=True)
 
                 lock_file = cache_file.with_name(cache_file.name + ".lock")
-                lock = self._file_lock_cls(lock_file)
-                try:
-                    yield AcquireLock(lock)
-                except UnsupportedAsyncLibrary:
-                    if not force:
-                        # The file lock doesn't support Trio, skip predicate
-                        # checking by setting None
-                        self._predicates[key] = None
-                        return self._predicates[key]
-                    lock_acquired = False
-                else:
-                    lock_acquired = True
+                # thread_local=False because the async client acquires and
+                # releases the lock from different worker threads.
+                lock = FileLock(lock_file, thread_local=False)
+                yield AcquireLock(lock)
 
                 try:
-                    if lock_acquired:
-                        predicates_data = self._read_cache_file(
-                            cache_file, PREDICATE_CACHE_EXPIRY_TIME
-                        )
+                    predicates_data = self._read_cache_file(
+                        cache_file, PREDICATE_CACHE_EXPIRY_TIME
+                    )
                     if predicates_data is None:
                         predicates_data = yield from self._download_predicate_data_generator(
                             class_, controller
                         )
-                        if lock_acquired:
-                            self._write_cache_file(cache_file, predicates_data)
+                        self._write_cache_file(cache_file, predicates_data)
                 finally:
-                    if lock_acquired:
-                        yield ReleaseLock(lock)
+                    yield ReleaseLock(lock)
 
             predicate_objects = self._parse_predicates_data(predicates_data)
 

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -177,8 +177,7 @@ async def test_ratelimit_error(
     assert mock_wait.call_args_list == [call(0.05), call(0.05)]
 
 
-@pytest.mark.asyncio
-async def test_modeldef_cache(httpx2_mock, mock_auth, cache_file_mangler):
+async def test_modeldef_cache(async_runner, httpx2_mock, mock_auth, cache_file_mangler):
     # This test creates three independently authenticated clients.
     mock_auth()
     mock_auth()
@@ -236,49 +235,6 @@ async def test_modeldef_cache(httpx2_mock, mock_auth, cache_file_mangler):
         # There should be a new modeldef request because we deleted the cache file
         assert await client.gp(norad_cat_id=25541) == "dummy"
         assert len(httpx2_mock.get_requests(method="GET", url=modeldef_url)) == 2
-
-
-@pytest.mark.trio
-async def test_modeldef_not_used_trio(httpx2_mock, mock_auth):
-    query_url = api_url("basicspacedata/query/class/gp/norad_cat_id/25541")
-    httpx2_mock.add_response(
-        method="GET", url=query_url, json="dummy", is_reusable=True
-    )
-
-    modeldef_url = api_url("basicspacedata/modeldef/class/gp")
-    httpx2_mock.add_response(
-        method="GET",
-        url=modeldef_url,
-        json={
-            "controller": "fileshare",
-            "data": [
-                {
-                    "Field": "NORAD_CAT_ID",
-                    "Type": "int(10) unsigned",
-                    "Null": "NO",
-                    "Key": "",
-                    "Default": None,
-                    "Extra": "",
-                },
-            ],
-        },
-    )
-
-    async with AsyncSpaceTrackClient("identity", "password") as client:
-        assert await client.gp(norad_cat_id=25541) == "dummy"
-        assert httpx2_mock.get_requests(method="GET", url=modeldef_url) == []
-
-        # If predicates are requested explicitly, they should be cached (in
-        # client only) and used
-        await client.gp.get_predicates()
-        assert len(httpx2_mock.get_requests(method="GET", url=modeldef_url)) == 1
-
-        assert await client.gp(norad_cat_id=25541) == "dummy"
-        assert len(httpx2_mock.get_requests(method="GET", url=modeldef_url)) == 1
-
-        cache_path = client._cache_path
-        cache_files = list(cache_path.glob("*.json"))
-        assert cache_files == []
 
 
 async def test_custom_cache_path(async_runner, httpx2_mock, tmp_path):

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -209,6 +209,16 @@ async def test_acquire_file_lock_waits_for_release(async_runner, client, tmp_pat
     lock.release()
 
 
+async def test_ratelimit_sync_callback(async_runner, client):
+    # The documentation shows a plain function callback for both clients.
+    calls = []
+    client.callback = calls.append
+
+    await client._ratelimit_wait(0)
+
+    assert len(calls) == 1
+
+
 async def test_modeldef_cache(async_runner, httpx2_mock, mock_auth, cache_file_mangler):
     # This test creates three independently authenticated clients.
     mock_auth()

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import call, patch
 
 import httpx2
@@ -143,27 +144,37 @@ async def test_ratelimit_error(
     )
     httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
 
-    # Change ratelimiter period to speed up test
-    client._per_minute_throttle.rate = Quota.per_second(30)
-
-    # Do it first without our own callback, then with.
-
-    assert await client.gp() == {"a": 1}
-    assert len(httpx2_mock.get_requests(method="GET", url=url)) == 2
-
-    mock_callback = AsyncMock()
-    client.callback = mock_callback
-
-    httpx2_mock.add_response(
-        method="GET", url=url, status_code=500, text="violated your query rate limit"
+    # Shrink the rate limit period so that the real _ratelimit_wait
+    # implementation only sleeps briefly.
+    client._per_minute_throttle.rate = Quota(
+        period=timedelta(milliseconds=50), count=30
     )
-    httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
 
-    assert await client.gp() == {"a": 1}
-    assert len(httpx2_mock.get_requests(method="GET", url=url)) == 4
+    with patch.object(
+        client, "_ratelimit_wait", wraps=client._ratelimit_wait
+    ) as mock_wait:
+        # Do it first without our own callback, then with.
+
+        assert await client.gp() == {"a": 1}
+        assert len(httpx2_mock.get_requests(method="GET", url=url)) == 2
+
+        mock_callback = AsyncMock()
+        client.callback = mock_callback
+
+        httpx2_mock.add_response(
+            method="GET",
+            url=url,
+            status_code=500,
+            text="violated your query rate limit",
+        )
+        httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
+
+        assert await client.gp() == {"a": 1}
+        assert len(httpx2_mock.get_requests(method="GET", url=url)) == 4
 
     assert mock_callback.call_count == 1
     mock_callback.assert_awaited()
+    assert mock_wait.call_args_list == [call(0.05), call(0.05)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,14 +1,16 @@
 from datetime import timedelta
 from unittest.mock import call, patch
 
+import anyio
 import httpx2
 import pytest
 import pytest_asyncio
+from filelock import FileLock
 from rush.quota import Quota
 
 from spacetrack import AsyncSpaceTrackClient
 from spacetrack.aio import _iter_content_generator
-from spacetrack.base import BASE_URL
+from spacetrack.base import BASE_URL, AcquireFileLock, ReleaseFileLock
 
 
 def api_url(path):
@@ -175,6 +177,36 @@ async def test_ratelimit_error(
     assert mock_callback.call_count == 1
     mock_callback.assert_awaited()
     assert mock_wait.call_args_list == [call(0.05), call(0.05)]
+
+
+async def test_release_lock_when_cancelled(async_runner, client, tmp_path):
+    # A cancelled scope must not skip the lock release, which would leak the
+    # predicate cache lock file.
+    lock = FileLock(tmp_path / "test.lock", thread_local=False)
+    lock.acquire(blocking=False)
+
+    with anyio.move_on_after(0):
+        await client._handle_event(ReleaseFileLock(lock))
+
+    assert not lock.is_locked
+
+
+async def test_acquire_file_lock_waits_for_release(async_runner, client, tmp_path):
+    path = tmp_path / "test.lock"
+    holder = FileLock(path, thread_local=False)
+    holder.acquire(blocking=False)
+    lock = FileLock(path, thread_local=False)
+
+    async def release_holder():
+        await anyio.sleep(0.2)
+        holder.release()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(release_holder)
+        await client._handle_event(AcquireFileLock(lock))
+
+    assert lock.is_locked
+    lock.release()
 
 
 async def test_modeldef_cache(async_runner, httpx2_mock, mock_auth, cache_file_mangler):

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -284,3 +284,8 @@ async def test_custom_cache_path(async_runner, httpx2_mock, tmp_path):
         "identity", "password", cache_path=tmp_path
     ) as client:
         assert client._cache_path == tmp_path
+
+
+async def test_unknown_event(async_runner, client):
+    with pytest.raises(RuntimeError, match="Unknown event type"):
+        await client._handle_event(object())

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -183,26 +183,36 @@ def test_ratelimit_error(client, httpx2_mock, mock_auth, mock_gp_predicates):
     )
     httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
 
-    # Change ratelimiter period to speed up test
-    client._per_minute_throttle.rate = Quota.per_second(30)
-
-    # Do it first without our own callback, then with.
-
-    assert client.gp() == {"a": 1}
-    assert len(httpx2_mock.get_requests(method="GET", url=url)) == 2
-
-    mock_callback = Mock()
-    client.callback = mock_callback
-
-    httpx2_mock.add_response(
-        method="GET", url=url, status_code=500, text="violated your query rate limit"
+    # Shrink the rate limit period so that the real _ratelimit_wait
+    # implementation only sleeps briefly.
+    client._per_minute_throttle.rate = Quota(
+        period=dt.timedelta(milliseconds=50), count=30
     )
-    httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
 
-    assert client.gp() == {"a": 1}
-    assert len(httpx2_mock.get_requests(method="GET", url=url)) == 4
+    with patch.object(
+        client, "_ratelimit_wait", wraps=client._ratelimit_wait
+    ) as mock_wait:
+        # Do it first without our own callback, then with.
+
+        assert client.gp() == {"a": 1}
+        assert len(httpx2_mock.get_requests(method="GET", url=url)) == 2
+
+        mock_callback = Mock()
+        client.callback = mock_callback
+
+        httpx2_mock.add_response(
+            method="GET",
+            url=url,
+            status_code=500,
+            text="violated your query rate limit",
+        )
+        httpx2_mock.add_response(method="GET", url=url, json={"a": 1})
+
+        assert client.gp() == {"a": 1}
+        assert len(httpx2_mock.get_requests(method="GET", url=url)) == 4
 
     assert mock_callback.call_count == 1
+    assert mock_wait.call_args_list == [call(0.05), call(0.05)]
 
 
 def test_non_ratelimit_error(client, httpx2_mock, mock_auth, mock_gp_predicates):

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -696,6 +696,11 @@ def test_modeldef_cache(httpx2_mock, mock_auth, cache_file_mangler):
         assert len(httpx2_mock.get_requests(method="GET", url=modeldef_url)) == 2
 
 
+def test_unknown_event(client):
+    with pytest.raises(RuntimeError, match="Unknown event type"):
+        client._handle_event(object())
+
+
 def test_implicit_cleanup_warning():
     with pytest.warns(ResourceWarning, match="without being closed explicitly"):
         SpaceTrackClient("identity", "password")

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -235,6 +235,23 @@ def test_non_ratelimit_error(client, httpx2_mock, mock_auth, mock_gp_predicates)
     assert not mock_callback.called
 
 
+def test_ratelimit_callback_error(client, httpx2_mock, mock_auth, mock_gp_predicates):
+    # Change ratelimiter period to speed up test
+    client._per_minute_throttle.rate = Quota(
+        period=dt.timedelta(milliseconds=50), count=30
+    )
+
+    url = api_url("basicspacedata/query/class/gp")
+    httpx2_mock.add_response(
+        method="GET", url=url, status_code=500, text="violated your query rate limit"
+    )
+
+    client.callback = Mock(side_effect=ValueError("boom"))
+
+    with pytest.raises(ValueError, match="boom"):
+        client.gp()
+
+
 def test_predicate_parse_modeldef(client):
     predicates_data = [
         {

--- a/uv.lock
+++ b/uv.lock
@@ -1085,6 +1085,7 @@ name = "spacetrack"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anyio" },
     { name = "filelock" },
     { name = "httpx2" },
     { name = "logbook" },
@@ -1150,6 +1151,7 @@ towncrier = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anyio", specifier = ">=4.10" },
     { name = "filelock", specifier = ">=3.17.0" },
     { name = "httpx2", specifier = ">=2.9.1" },
     { name = "logbook", specifier = ">=1.10.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,6 @@ dependencies = [
     { name = "python-dateutil", marker = "python_full_version < '3.11'" },
     { name = "represent" },
     { name = "rush" },
-    { name = "sniffio" },
 ]
 
 [package.dev-dependencies]
@@ -1160,7 +1159,6 @@ requires-dist = [
     { name = "python-dateutil", marker = "python_full_version < '3.11'", specifier = ">=2.9.0.post0" },
     { name = "represent", specifier = ">=2.1" },
     { name = "rush", specifier = ">=2021.4.0" },
-    { name = "sniffio", specifier = ">=1.3.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Rate limit waits now wait for the callback to finish in all clients, and an exception raised by the callback propagates instead of being silently discarded, including in the sync client. The async client accepts a plain function as the callback, as the documentation shows.

The predicate cache now works on trio, with cache file I/O running in a worker thread, and the cache file lock is released correctly when a request is cancelled.

The event classes are modernised to `attrs.define`, and the file lock events are named explicitly.