### PR TITLE
Avoid duplicate logins from concurrent requests

### DIFF
--- a/newsfragments/161.fixed.rst
+++ b/newsfragments/161.fixed.rst
@@ -1,0 +1,1 @@
+Concurrent first requests on a fresh client now share a single login request instead of each sending their own.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.15",
 ]
 dependencies = [
-    "anyio>=4.10",
+    "anyio>=4.12",
     "filelock>=3.17.0",
     "httpx2>=2.9.1",
     "logbook>=1.10.1",
@@ -72,8 +72,7 @@ nox = [
 test = [
     "httpx2-pytest>=1.0.1",
     "pytest>=9.0.3",
-    "pytest-asyncio>=1.4.0",
-    "pytest-trio>=0.8.0",
+    "trio>=0.33.0",
 ]
 towncrier = [
     "towncrier>=25.8.0",
@@ -101,7 +100,6 @@ exclude_also = [
 
 [tool.pytest]
 addopts = ["-r", "s"]
-asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 
 [tool.ruff.lint]

--- a/src/spacetrack/aio.py
+++ b/src/spacetrack/aio.py
@@ -11,6 +11,7 @@ from httpx2 import USE_CLIENT_DEFAULT
 
 from .base import (
     BASE_URL,
+    AcquireAuthLock,
     AcquireFileLock,
     Event,
     IterContent,
@@ -18,6 +19,7 @@ from .base import (
     NormalRequest,
     RateLimitWait,
     ReadResponse,
+    ReleaseAuthLock,
     ReleaseFileLock,
     RunBlocking,
     SpaceTrackClient,
@@ -74,6 +76,11 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             ),
         )
 
+    def _create_auth_lock(self):
+        # When no event loop is running during __init__, the lock binds to
+        # the async backend it is first used under.
+        return anyio.Lock()
+
     async def _handle_event(self, event):
         if isinstance(event, NormalRequest):
             return await self.client.send(
@@ -113,6 +120,12 @@ class AsyncSpaceTrackClient(SpaceTrackClient):
             # leak the lock.
             with anyio.CancelScope(shield=True):
                 await anyio.to_thread.run_sync(event.lock.release)
+        elif isinstance(event, AcquireAuthLock):
+            # anyio.Lock acquisition is cancellation-safe, and the release
+            # below is synchronous, so neither needs shielding.
+            await self._auth_lock.acquire()
+        elif isinstance(event, ReleaseAuthLock):
+            self._auth_lock.release()
         elif isinstance(event, RunBlocking):
             return await anyio.to_thread.run_sync(event.func)
         else:

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -119,6 +119,16 @@ class ReleaseFileLock(Event):
 
 
 @define
+class AcquireAuthLock(Event):
+    pass
+
+
+@define
+class ReleaseAuthLock(Event):
+    pass
+
+
+@define
 class RunBlocking(Event):
     func: Callable[[], Any]
 
@@ -329,6 +339,7 @@ class SpaceTrackClient:
         self.callback = None
 
         self._authenticated = False
+        self._auth_lock = self._create_auth_lock()
         self._predicates = dict()
         self._controller_proxies = dict()
 
@@ -379,6 +390,9 @@ class SpaceTrackClient:
             ),
         )
 
+    def _create_auth_lock(self):
+        return threading.Lock()
+
     @property
     def base_url(self):
         return str(self.client.base_url)
@@ -406,6 +420,10 @@ class SpaceTrackClient:
             event.lock.acquire()
         elif isinstance(event, ReleaseFileLock):
             event.lock.release()
+        elif isinstance(event, AcquireAuthLock):
+            self._auth_lock.acquire()
+        elif isinstance(event, ReleaseAuthLock):
+            self._auth_lock.release()
         elif isinstance(event, RunBlocking):
             return event.func()
         else:
@@ -433,19 +451,28 @@ class SpaceTrackClient:
         if self._authenticated:
             return
 
-        data = {"identity": self.identity, "password": self.password}
-        resp = yield NormalRequest(
-            self.client.build_request("POST", "ajaxauth/login", data=data)
-        )
-        _raise_for_status(resp)
+        yield AcquireAuthLock()
+        try:
+            # Another thread or task may have authenticated while we were
+            # waiting for the lock.
+            if self._authenticated:
+                return
 
-        # If login failed, we get a JSON response with {'Login': 'Failed'}
-        resp_data = resp.json()
-        if isinstance(resp_data, Mapping):
-            if resp_data.get("Login", None) == "Failed":
-                raise AuthenticationError()
+            data = {"identity": self.identity, "password": self.password}
+            resp = yield NormalRequest(
+                self.client.build_request("POST", "ajaxauth/login", data=data)
+            )
+            _raise_for_status(resp)
 
-        self._authenticated = True
+            # If login failed, we get a JSON response with {'Login': 'Failed'}
+            resp_data = resp.json()
+            if isinstance(resp_data, Mapping):
+                if resp_data.get("Login", None) == "Failed":
+                    raise AuthenticationError()
+
+            self._authenticated = True
+        finally:
+            yield ReleaseAuthLock()
 
     def _logout_generator(self):
         if not self._authenticated:

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -206,6 +206,15 @@ async def test_ratelimit_sync_callback(client):
     assert len(calls) == 1
 
 
+async def test_concurrent_authenticate(client, httpx2_mock, mock_auth):
+    async with anyio.create_task_group() as tg:
+        for _ in range(5):
+            tg.start_soon(client.authenticate)
+
+    login_url = api_url("ajaxauth/login")
+    assert len(httpx2_mock.get_requests(method="POST", url=login_url)) == 1
+
+
 async def test_modeldef_cache(httpx2_mock, mock_auth, cache_file_mangler):
     # This test creates three independently authenticated clients.
     mock_auth()

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -4,7 +4,6 @@ from unittest.mock import call, patch
 import anyio
 import httpx2
 import pytest
-import pytest_asyncio
 from filelock import FileLock
 from rush.quota import Quota
 
@@ -12,28 +11,20 @@ from spacetrack import AsyncSpaceTrackClient
 from spacetrack.aio import _iter_content_generator
 from spacetrack.base import BASE_URL, AcquireFileLock, ReleaseFileLock
 
+pytestmark = pytest.mark.anyio
+
 
 def api_url(path):
     return f"{BASE_URL}{path}"
 
 
-@pytest.fixture(
-    params=[
-        pytest.param("asyncio", marks=pytest.mark.asyncio),
-        pytest.param("trio", marks=pytest.mark.trio),
-    ]
-)
-def async_runner(request):
-    return request.param
-
-
-@pytest_asyncio.fixture
+@pytest.fixture
 async def client(httpx2_mock):
     async with AsyncSpaceTrackClient("identity", "password") as st:
         yield st
 
 
-async def test_custom_httpx_client(async_runner):
+async def test_custom_httpx_client():
     httpx_client = httpx2.AsyncClient()
 
     async with AsyncSpaceTrackClient(
@@ -45,11 +36,11 @@ async def test_custom_httpx_client(async_runner):
         AsyncSpaceTrackClient("identity", "password", httpx_client=object())
 
 
-async def test_authenticate(client, async_runner, mock_auth):
+async def test_authenticate(client, mock_auth):
     await client.authenticate()
 
 
-async def test_get_predicates_calls(async_runner, client):
+async def test_get_predicates_calls(client):
     patch_get_predicates = patch.object(client, "get_predicates")
 
     with patch_get_predicates as mock_get_predicates:
@@ -70,7 +61,7 @@ async def test_get_predicates_calls(async_runner, client):
         assert mock_get_predicates.await_args_list == expected_calls
 
 
-async def test_get_predicates(async_runner, client, mock_auth, mock_gp_predicates):
+async def test_get_predicates(client, mock_auth, mock_gp_predicates):
     predicates = await client.gp.get_predicates()
 
     assert {predicate.name for predicate in predicates} >= {
@@ -80,9 +71,7 @@ async def test_get_predicates(async_runner, client, mock_auth, mock_gp_predicate
     }
 
 
-async def test_generic_request(
-    client, async_runner, httpx2_mock, mock_auth, mock_gp_predicates
-):
+async def test_generic_request(client, httpx2_mock, mock_auth, mock_gp_predicates):
     tle = (
         "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n"
         "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537\r\n"
@@ -104,7 +93,7 @@ async def test_generic_request(
     assert result["a"] == 5
 
 
-async def test_iter_content_generator(async_runner):
+async def test_iter_content_generator():
     """Test CRLF -> LF newline conversion."""
 
     async def mock_aiter_bytes():
@@ -135,9 +124,7 @@ async def test_iter_content_generator(async_runner):
         assert result == [b"1\r\n2\r\n", b"3\r", b"\n4", b"\r\n5"]
 
 
-async def test_ratelimit_error(
-    async_runner, client, httpx2_mock, mock_auth, mock_gp_predicates
-):
+async def test_ratelimit_error(client, httpx2_mock, mock_auth, mock_gp_predicates):
     from unittest.mock import AsyncMock
 
     url = api_url("basicspacedata/query/class/gp")
@@ -179,7 +166,7 @@ async def test_ratelimit_error(
     assert mock_wait.call_args_list == [call(0.05), call(0.05)]
 
 
-async def test_release_lock_when_cancelled(async_runner, client, tmp_path):
+async def test_release_lock_when_cancelled(client, tmp_path):
     # A cancelled scope must not skip the lock release, which would leak the
     # predicate cache lock file.
     lock = FileLock(tmp_path / "test.lock", thread_local=False)
@@ -191,7 +178,7 @@ async def test_release_lock_when_cancelled(async_runner, client, tmp_path):
     assert not lock.is_locked
 
 
-async def test_acquire_file_lock_waits_for_release(async_runner, client, tmp_path):
+async def test_acquire_file_lock_waits_for_release(client, tmp_path):
     path = tmp_path / "test.lock"
     holder = FileLock(path, thread_local=False)
     holder.acquire(blocking=False)
@@ -209,7 +196,7 @@ async def test_acquire_file_lock_waits_for_release(async_runner, client, tmp_pat
     lock.release()
 
 
-async def test_ratelimit_sync_callback(async_runner, client):
+async def test_ratelimit_sync_callback(client):
     # The documentation shows a plain function callback for both clients.
     calls = []
     client.callback = calls.append
@@ -219,7 +206,7 @@ async def test_ratelimit_sync_callback(async_runner, client):
     assert len(calls) == 1
 
 
-async def test_modeldef_cache(async_runner, httpx2_mock, mock_auth, cache_file_mangler):
+async def test_modeldef_cache(httpx2_mock, mock_auth, cache_file_mangler):
     # This test creates three independently authenticated clients.
     mock_auth()
     mock_auth()
@@ -279,13 +266,13 @@ async def test_modeldef_cache(async_runner, httpx2_mock, mock_auth, cache_file_m
         assert len(httpx2_mock.get_requests(method="GET", url=modeldef_url)) == 2
 
 
-async def test_custom_cache_path(async_runner, httpx2_mock, tmp_path):
+async def test_custom_cache_path(httpx2_mock, tmp_path):
     async with AsyncSpaceTrackClient(
         "identity", "password", cache_path=tmp_path
     ) as client:
         assert client._cache_path == tmp_path
 
 
-async def test_unknown_event(async_runner, client):
+async def test_unknown_event(client):
     with pytest.raises(RuntimeError, match="Unknown event type"):
         await client._handle_event(object())

--- a/uv.lock
+++ b/uv.lock
@@ -70,15 +70,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-asyncio-runner"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -901,34 +892,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-asyncio"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
-]
-
-[[package]]
-name = "pytest-trio"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "outcome" },
-    { name = "pytest" },
-    { name = "trio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/08/056279526554c6c6e6ad6d4a479a338d14dc785ac30be8bdc6ca0153c1be/pytest-trio-0.8.0.tar.gz", hash = "sha256:8363db6336a79e6c53375a2123a41ddbeccc4aa93f93788651641789a56fb52e", size = 46525, upload-time = "2022-11-01T17:24:29.352Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/22/71953f47e0da5852c899f58cd7a31e6100f37c632b7b9ee52d067613a844/pytest_trio-0.8.0-py3-none-any.whl", hash = "sha256:e6a7e7351ae3e8ec3f4564d30ee77d1ec66e1df611226e5618dbb32f9545c841", size = 27221, upload-time = "2022-11-01T17:24:27.501Z" },
-]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1112,13 +1075,12 @@ dev = [
     { name = "nox" },
     { name = "parver" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-trio" },
     { name = "ruff" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "towncrier" },
+    { name = "trio" },
 ]
 docs = [
     { name = "furo" },
@@ -1141,8 +1103,7 @@ nox = [
 test = [
     { name = "httpx2-pytest" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-trio" },
+    { name = "trio" },
 ]
 towncrier = [
     { name = "towncrier" },
@@ -1150,7 +1111,7 @@ towncrier = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", specifier = ">=4.10" },
+    { name = "anyio", specifier = ">=4.12" },
     { name = "filelock", specifier = ">=3.17.0" },
     { name = "httpx2", specifier = ">=2.9.1" },
     { name = "logbook", specifier = ">=1.10.1" },
@@ -1173,11 +1134,10 @@ dev = [
     { name = "nox", specifier = ">=2026.4.10" },
     { name = "parver", specifier = ">=0.5" },
     { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
-    { name = "pytest-trio", specifier = ">=0.8.0" },
     { name = "ruff", specifier = "==0.15.16" },
     { name = "sphinx", specifier = ">=7.4.7" },
     { name = "towncrier", specifier = ">=25.8.0" },
+    { name = "trio", specifier = ">=0.33.0" },
 ]
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
@@ -1194,8 +1154,7 @@ nox = [{ name = "nox", specifier = ">=2026.4.10" }]
 test = [
     { name = "httpx2-pytest", specifier = ">=1.0.1" },
     { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.4.0" },
-    { name = "pytest-trio", specifier = ">=0.8.0" },
+    { name = "trio", specifier = ">=0.33.0" },
 ]
 towncrier = [{ name = "towncrier", specifier = ">=25.8.0" }]
 


### PR DESCRIPTION
Concurrent first requests on a fresh client each sent their own login request. The login is now guarded by a per-client lock, so only one login is sent and the other requests wait for it.

The async tests now run under anyio's pytest plugin so that fixtures run on the same backend as the test, which replaces pytest-asyncio and pytest-trio.