### PR TITLE
Log in again automatically when the session expires

### DIFF
--- a/newsfragments/164.changed.rst
+++ b/newsfragments/164.changed.rst
@@ -1,0 +1,1 @@
+When the Space-Track session expires (after two hours without requests), the client now logs in again and retries the request transparently instead of failing every subsequent request.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -614,13 +614,15 @@ class SpaceTrackClient:
                 timeout=timeout,
             )
             logger.debug(request.url)
-            resp = yield from self._ratelimited_send_generator(request)
+            resp = yield from self._authenticated_send_generator(
+                request, retry=_can_resend_file(kwargs["file"])
+            )
         else:
             request = self.client.build_request(
                 "GET", url, params=params, timeout=timeout
             )
             logger.debug(request.url)
-            resp = yield from self._ratelimited_send_generator(
+            resp = yield from self._authenticated_send_generator(
                 request, stream=iter_lines or iter_content
             )
 
@@ -811,6 +813,32 @@ class SpaceTrackClient:
 
         return resp
 
+    def _authenticated_send_generator(self, request, *, stream=False, retry=True):
+        """Send a request, re-authenticating and retrying once if the session
+        has expired.
+
+        Space-Track sessions last two hours and are refreshed by activity, so
+        only a client that has been idle for longer than that gets a 401 here.
+
+        Pass ``retry=False`` if the request body cannot be sent a second time.
+        """
+        resp = yield from self._ratelimited_send_generator(request, stream=stream)
+
+        if resp.status_code == 401 and retry:
+            # Consume a streamed response so its connection is released before
+            # retrying.
+            yield ReadResponse(resp)
+            self._authenticated = False
+            yield from self._auth_generator()
+            # The Cookie header was set when the request was built, so replace
+            # it with the new session cookie. The jar only sets the header if
+            # the request doesn't have one.
+            request.headers.pop("Cookie", None)
+            self.client.cookies.set_cookie_header(request)
+            resp = yield from self._ratelimited_send_generator(request, stream=stream)
+
+        return resp
+
     def _ratelimit_callback(self, until):
         duration = round(until - time.monotonic())
         logger.info("Rate limit reached. Sleeping for {:d} seconds.", duration)
@@ -894,7 +922,7 @@ class SpaceTrackClient:
         req = self.client.build_request("GET", url)
         logger.debug(req.url)
 
-        resp = yield from self._ratelimited_send_generator(req)
+        resp = yield from self._authenticated_send_generator(req)
 
         _raise_for_status(resp)
 
@@ -1132,6 +1160,21 @@ class _ControllerProxy:
         controller.
         """
         return self.client.get_predicates(class_=class_, controller=self.controller)
+
+
+def _can_resend_file(file):
+    """Whether an upload's ``file`` can be sent again after a failed attempt.
+
+    HTTPX rewinds seekable file objects before sending, but a non-seekable
+    stream would be sent empty the second time.
+    """
+    if isinstance(file, (tuple, list)):
+        # (filename, file, ...)
+        file = file[1]
+    if isinstance(file, (bytes, str)):
+        return True
+    seekable = getattr(file, "seekable", None)
+    return callable(seekable) and seekable()
 
 
 def _iter_lines_generator(response):

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -153,6 +153,16 @@ def test_generic_request(httpx2_mock, client, mock_auth, mock_gp_predicates):
     assert "".join(result) == "abcdef"
 
 
+def test_upload(client, httpx2_mock, mock_auth):
+    url = api_url("fileshare/query/class/upload/folder_id/123")
+    httpx2_mock.add_response(method="POST", url=url, json="ok")
+
+    assert client.upload(folder_id=123, file=io.BytesIO(b"file contents")) == "ok"
+
+    request = httpx2_mock.get_request(method="POST", url=url)
+    assert b"file contents" in request.content
+
+
 def test_predicate_error(client, mock_auth, mock_predicates_empty):
     with pytest.raises(TypeError, match=r"unexpected argument 'banana'"):
         client.gp(banana=4)

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import io
+import os
 from unittest.mock import Mock, call, patch
 
 import httpx2
@@ -14,6 +16,7 @@ from spacetrack import (
 from spacetrack.base import (
     BASE_URL,
     Predicate,
+    _can_resend_file,
     _iter_content_generator,
     _raise_for_status,
 )
@@ -486,6 +489,119 @@ def test_authenticate(httpx2_mock):
 
     with SpaceTrackClient("identity", "unknownresponse") as client:
         client.authenticate()
+
+
+def test_expired_session_reauthenticates(client, httpx2_mock, mock_gp_predicates):
+    url = api_url("basicspacedata/query/class/gp")
+    login_url = api_url("ajaxauth/login")
+
+    # Record the session cookie as each query arrives, since the same request
+    # object is sent again after re-authentication.
+    cookies = []
+    responses = iter(
+        [
+            httpx2.Response(200, json={"a": 1}),
+            # Space-Track sessions expire after two hours of inactivity; the
+            # next query gets a 401 and the client must re-authenticate and
+            # retry transparently, with the new session cookie.
+            httpx2.Response(
+                401, json={"error": "You must be logged in to complete this action"}
+            ),
+            httpx2.Response(200, json={"a": 2}),
+        ]
+    )
+
+    def query(request):
+        cookies.append(request.headers["cookie"])
+        return next(responses)
+
+    httpx2_mock.add_callback(query, method="GET", url=url, is_reusable=True)
+    httpx2_mock.add_response(
+        method="POST",
+        url=login_url,
+        json="",
+        headers={"set-cookie": "chocolatechip=old; Path=/"},
+    )
+    httpx2_mock.add_response(
+        method="POST",
+        url=login_url,
+        json="",
+        headers={"set-cookie": "chocolatechip=new; Path=/"},
+    )
+    httpx2_mock.add_response(method="GET", url=api_url("ajaxauth/logout"), json="")
+
+    assert client.gp() == {"a": 1}
+    assert client.gp() == {"a": 2}
+
+    assert cookies == ["chocolatechip=old", "chocolatechip=old", "chocolatechip=new"]
+
+
+@pytest.mark.parametrize(
+    "file, expected",
+    [
+        (b"contents", True),
+        ("contents", True),
+        (io.BytesIO(b"contents"), True),
+        (("name.txt", io.BytesIO(b"contents")), True),
+        (("name.txt", b"contents", "text/plain"), True),
+        (object(), False),
+    ],
+)
+def test_can_resend_file(file, expected):
+    assert _can_resend_file(file) is expected
+
+
+def test_expired_session_upload_retried(client, httpx2_mock, mock_auth):
+    url = api_url("fileshare/query/class/upload/folder_id/123")
+    httpx2_mock.add_response(method="POST", url=url, status_code=401)
+    httpx2_mock.add_response(method="POST", url=api_url("ajaxauth/login"), json="")
+    httpx2_mock.add_response(method="POST", url=url, json="ok")
+
+    assert client.upload(folder_id=123, file=io.BytesIO(b"file contents")) == "ok"
+
+    # A seekable file is rewound, so both attempts carry the full body.
+    bodies = [r.content for r in httpx2_mock.get_requests(method="POST", url=url)]
+    assert len(bodies) == 2
+    assert all(b"file contents" in body for body in bodies)
+
+
+def test_expired_session_upload_not_retried(client, httpx2_mock, mock_auth):
+    url = api_url("fileshare/query/class/upload/folder_id/123")
+    httpx2_mock.add_response(method="POST", url=url, status_code=401)
+
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, b"file contents")
+    os.close(write_fd)
+
+    # A non-seekable stream cannot be sent again, so there is no transparent
+    # retry and the error propagates.
+    with os.fdopen(read_fd, "rb") as stream:
+        with pytest.raises(httpx2.HTTPStatusError):
+            client.upload(folder_id=123, file=stream)
+
+    assert len(httpx2_mock.get_requests(method="POST", url=url)) == 1
+
+
+def test_expired_session_retries_once(
+    client, httpx2_mock, mock_auth, mock_gp_predicates
+):
+    url = api_url("basicspacedata/query/class/gp")
+    login_url = api_url("ajaxauth/login")
+
+    httpx2_mock.add_response(
+        method="GET",
+        url=url,
+        status_code=401,
+        json={"error": "You must be logged in to complete this action"},
+        is_reusable=True,
+    )
+    httpx2_mock.add_response(method="POST", url=login_url, json="")
+
+    with pytest.raises(httpx2.HTTPStatusError):
+        client.gp()
+
+    # One transparent retry only; a second 401 raises.
+    assert len(httpx2_mock.get_requests(method="GET", url=url)) == 2
 
 
 def test_base_url(httpx2_mock):


### PR DESCRIPTION
A session that expired after two hours without requests caused every subsequent request to fail, since the client never logged in again. A 401 response now triggers a fresh login and a single retry of the request.

Confirmed against the live API: sessions are extended by activity, and an idle session returns a 401 with a JSON error body.