### PR TITLE
Fix controller proxies after the client is garbage collected

### DIFF
--- a/newsfragments/167.fixed.rst
+++ b/newsfragments/167.fixed.rst
@@ -1,0 +1,1 @@
+Fixed a :class:`ReferenceError` when chaining a request off a temporary client, e.g. ``SpaceTrackClient(...).basicspacedata.gp(...)``.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -1090,9 +1090,7 @@ class _ControllerProxy:
     """Proxies request class methods with a preset request controller."""
 
     def __init__(self, client, controller):
-        # The client will cache _ControllerProxy instances, so only store
-        # a weak reference to it.
-        self.client = weakref.proxy(client)
+        self.client = client
         self.controller = controller
 
     def __getattr__(self, attr):

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -368,6 +368,16 @@ def test_controller_spacetrack_methods(client):
                 assert mock_generic_request.call_args == expected
 
 
+def test_controller_proxy_keeps_client_alive(httpx2_mock):
+    # A _ControllerProxy used to hold only a weak reference, so using a
+    # proxy after the client's last strong reference was dropped raised
+    # ReferenceError.
+    with patch.object(SpaceTrackClient, "generic_request") as mock_generic_request:
+        SpaceTrackClient("identity", "password").basicspacedata.gp()
+
+    mock_generic_request.assert_called_once()
+
+
 def test_authenticate(httpx2_mock):
     def request_callback(request):
         if b"wrongpassword" in request.content:


### PR DESCRIPTION
The proxy stored weakref.proxy(client), but nothing else kept the
client alive, so the one-expression idiom
SpaceTrackClient(...).basicspacedata.gp(...) collected the client
mid-expression and raised ReferenceError, and hasattr/getattr on a
proxy that outlived its client raised ReferenceError instead of
reporting the attribute missing. The client-to-proxy reference cycle
this creates is handled by the garbage collector, and the finalizer
still fires because it does not reference the instance.
