### PR TITLE
Fix get_predicates for classes without a model definition

### DIFF
--- a/newsfragments/168.fixed.rst
+++ b/newsfragments/168.fixed.rst
@@ -1,0 +1,2 @@
+:meth:`~spacetrack.base.SpaceTrackClient.get_predicates` now returns the known predicates for request classes without a model definition on Space-Track (such as ``fileshare/download`` and ``publicfiles/dirs``) instead of failing.
+The returned :class:`~spacetrack.base.Predicate` objects have a ``type_`` of ``None``, since no model definition exists to provide it.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -897,6 +897,12 @@ class SpaceTrackClient:
             if class_ not in classes:
                 raise ValueError(f"Unknown request class {class_!r}")
 
+        if (class_, controller) in self.offline_predicates:
+            return [
+                Predicate(name, None)
+                for name in sorted(self.offline_predicates[(class_, controller)])
+            ]
+
         key = f"{controller}.{class_}"
 
         if key not in self._predicates or (force and self._predicates[key] is None):

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -108,6 +108,20 @@ def test_get_predicates(client):
         assert mock_get_predicates.call_args_list == expected_calls
 
 
+def test_get_predicates_offline_class(client, httpx2_mock):
+    predicates = client.get_predicates("download", "fileshare")
+
+    assert {predicate.name for predicate in predicates} == {
+        "file_id",
+        "folder_id",
+        "recursive",
+    }
+    # No model definition exists for these classes, so the types are unknown.
+    assert all(predicate.type_ is None for predicate in predicates)
+
+    assert client.spephemeris.download.get_predicates() == []
+
+
 def test_generic_request(httpx2_mock, client, mock_auth, mock_gp_predicates):
     tle = (
         "1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927\r\n"


### PR DESCRIPTION
get_predicates requested a model definition even for the classes that
offline_predicates documents as not having one, so the call always
failed for them. Return the known predicate names instead of fetching.
