### PR TITLE
Accept sets and reject bytes as predicate values

### DIFF
--- a/newsfragments/169.changed.rst
+++ b/newsfragments/169.changed.rst
@@ -1,0 +1,2 @@
+Sets and frozensets are now accepted as predicate values and joined with commas like sequences.
+Bytes-like values now raise :class:`TypeError` instead of being sent as comma-separated integers.

--- a/src/spacetrack/operators.py
+++ b/src/spacetrack/operators.py
@@ -1,5 +1,5 @@
 import datetime
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 
 
 def greater_than(value):
@@ -36,13 +36,17 @@ def _stringify_predicate_value(value):
     """Convert Python objects to Space-Track compatible strings
 
     - Booleans (``True`` -> ``'true'``)
-    - Sequences (``[25544, 34602]`` -> ``'25544,34602'``)
+    - Sequences and sets (``[25544, 34602]`` -> ``'25544,34602'``)
     - dates/datetimes (``date(2015, 12, 23)`` -> ``'2015-12-23'``)
     - ``None`` -> ``'null-val'``
     """
     if isinstance(value, bool):
         return str(value).lower()
-    elif isinstance(value, Sequence) and not isinstance(value, str):
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        raise TypeError(
+            f"predicate values of type {type(value).__name__!r} are not supported"
+        )
+    elif isinstance(value, (Sequence, Set)) and not isinstance(value, str):
         return ",".join(_stringify_predicate_value(x) for x in value)
     elif isinstance(value, datetime.datetime):
         if value.tzinfo is not None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -10,6 +10,8 @@ stringify_data = [
     (False, "false"),
     ([1, 2], "1,2"),
     (["a", "b"], "a,b"),
+    ({1}, "1"),
+    (frozenset(["a"]), "a"),
     ((dt.date(2001, 2, 3), dt.date(2004, 5, 6)), "2001-02-03,2004-05-06"),
     (dt.datetime(2001, 2, 3, 4, 5, 6), "2001-02-03 04:05:06"),
     (dt.datetime(2001, 2, 3, tzinfo=dt.timezone.utc), "2001-02-03 00:00:00"),
@@ -21,6 +23,13 @@ stringify_data = [
 @pytest.mark.parametrize("value, expected", stringify_data)
 def test_stringify_predicate_value(value, expected):
     assert _stringify_predicate_value(value) == expected
+
+
+@pytest.mark.parametrize("value", [b"abc", bytearray(b"abc"), memoryview(b"abc")])
+def test_stringify_predicate_value_rejects_bytes(value):
+    # bytes would otherwise be serialised as comma-joined integer ordinals.
+    with pytest.raises(TypeError):
+        _stringify_predicate_value(value)
 
 
 operator_data = [


### PR DESCRIPTION
Sets and frozensets fell through to str(), silently sending values like
'{25544, 34602}' in the query URL where a list sends '25544,34602'.
bytes are registered Sequences, so they were serialised as comma-joined
integer ordinals. Join Set values like Sequences, and raise TypeError
for bytes-like values instead of building a garbage query.
