### PR TITLE
Fix parse_types with metadata=True

### DIFF
--- a/newsfragments/170.fixed.rst
+++ b/newsfragments/170.fixed.rst
@@ -1,0 +1,1 @@
+``parse_types=True`` now works together with ``metadata=True`` in :meth:`~spacetrack.base.SpaceTrackClient.generic_request` and the request class methods; previously the metadata-wrapped response made it fail after the request had succeeded.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -747,7 +747,11 @@ class SpaceTrackClient:
     def _parse_types(data, predicates):
         predicate_map = {p.name: p for p in predicates}
 
-        for obj in data:
+        # With metadata=true, the rows are wrapped in a dict alongside the
+        # request metadata.
+        rows = data.get("data", []) if isinstance(data, Mapping) else data
+
+        for obj in rows:
             for key, value in obj.items():
                 if key.lower() in predicate_map:
                     obj[key] = predicate_map[key.lower()].parse(value)

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -621,6 +621,21 @@ def test_parse_types(client, httpx2_mock, mock_auth):
     assert "parse_types" in exc_info.value.args[0]
 
 
+def test_parse_types_metadata(client, httpx2_mock, mock_auth, mock_gp_predicates):
+    httpx2_mock.add_response(
+        method="GET",
+        url=api_url("basicspacedata/query/class/gp/metadata/true"),
+        json={
+            "request_metadata": {"DataSize": "1"},
+            "data": [{"LAUNCH_DATE": "2017-01-01"}],
+        },
+    )
+
+    result = client.gp(parse_types=True, metadata=True)
+
+    assert result["data"][0]["LAUNCH_DATE"] == dt.date(2017, 1, 1)
+
+
 def test_params(httpx2_mock, mock_auth):
     data = b"hello\n"
     httpx2_mock.add_response(


### PR DESCRIPTION
With metadata=true, Space-Track wraps the rows in a dict alongside the
request metadata, and _parse_types crashed iterating the dict's keys
after the request had already succeeded. Unwrap the rows and leave the
response shape unchanged.
