### PR TITLE
Fix positional arguments to request class methods

### DIFF
--- a/newsfragments/171.fixed.rst
+++ b/newsfragments/171.fixed.rst
@@ -1,0 +1,2 @@
+Fixed a :class:`TypeError` when passing positional arguments to request class methods such as ``client.gp_history(...)``.
+The request class was bound as a keyword argument internally, so any positional argument clashed with it.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -840,9 +840,9 @@ class SpaceTrackClient:
         # generic_request can resolve the controller itself, but we
         # pass it because we have to check if the class_ is owned
         # by a controller here anyway.
-        function = partial(self.generic_request, class_=attr, controller=controller)
+        function = partial(self.generic_request, attr, controller=controller)
         function.get_predicates = partial(
-            self.get_predicates, class_=attr, controller=controller
+            self.get_predicates, attr, controller=controller
         )
         return function
 
@@ -1100,10 +1100,10 @@ class _ControllerProxy:
             raise AttributeError(f"'{self!r}' object has no attribute '{attr}'")
 
         function = partial(
-            self.client.generic_request, class_=attr, controller=self.controller
+            self.client.generic_request, attr, controller=self.controller
         )
         function.get_predicates = partial(
-            self.client.get_predicates, class_=attr, controller=self.controller
+            self.client.get_predicates, attr, controller=self.controller
         )
 
         return function
@@ -1118,7 +1118,7 @@ class _ControllerProxy:
         """Proxy ``get_predicates`` to client with stored request
         controller.
         """
-        return self.client.get_predicates(class_=class_, controller=self.controller)
+        return self.client.get_predicates(class_, controller=self.controller)
 
 
 def _iter_lines_generator(response):

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -51,9 +51,9 @@ async def test_get_predicates_calls(client):
         await client.get_predicates("gp", "basicspacedata")
 
         expected_calls = [
-            call(class_="gp", controller="basicspacedata"),
-            call(class_="gp", controller="basicspacedata"),
-            call(class_="gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
             call("gp"),
             call("gp", "basicspacedata"),
         ]

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -98,9 +98,9 @@ def test_get_predicates(client):
         client.get_predicates("gp", "basicspacedata")
 
         expected_calls = [
-            call(class_="gp", controller="basicspacedata"),
-            call(class_="gp", controller="basicspacedata"),
-            call(class_="gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
+            call("gp", controller="basicspacedata"),
             call("gp"),
             call("gp", "basicspacedata"),
         ]
@@ -350,11 +350,22 @@ def test_bare_spacetrack_methods(client):
                 seen.add(class_)
                 method = getattr(client, class_)
                 method()
-                expected = call(class_=class_, controller=controller)
+                expected = call(class_, controller=controller)
                 assert mock_generic_request.call_args == expected
 
     with pytest.raises(AttributeError):
         client.madeupmethod()
+
+
+def test_positional_arguments(client):
+    # The generic_request docstring documents st.gp_history(*args, **kw) as
+    # equivalent to st.generic_request('gp_history', *args, **kw).
+    with patch.object(SpaceTrackClient, "generic_request") as mock_generic_request:
+        client.gp_history(True)
+
+    assert mock_generic_request.call_args == call(
+        "gp_history", True, controller="basicspacedata"
+    )
 
 
 def test_controller_spacetrack_methods(client):
@@ -364,7 +375,7 @@ def test_controller_spacetrack_methods(client):
                 controller_proxy = getattr(client, controller)
                 method = getattr(controller_proxy, class_)
                 method()
-                expected = call(class_=class_, controller=controller)
+                expected = call(class_, controller=controller)
                 assert mock_generic_request.call_args == expected
 
 


### PR DESCRIPTION
The forged methods bound class_ as a keyword in functools.partial, so
the documented equivalence st.gp_history(*args, **kw) ->
st.generic_request('gp_history', *args, **kw) raised TypeError for any
positional argument, which landed in the class_ slot.
