### PR TITLE
Handle non-string error values in error responses

### DIFF
--- a/newsfragments/172.fixed.rst
+++ b/newsfragments/172.fixed.rst
@@ -1,0 +1,1 @@
+Error responses whose JSON ``error`` value is not a string no longer raise :class:`TypeError` instead of ``httpx2.HTTPStatusError``.

--- a/src/spacetrack/base.py
+++ b/src/spacetrack/base.py
@@ -1157,7 +1157,7 @@ def _raise_for_status(response):
 
         try:
             json = response.json()
-            if isinstance(json, Mapping):
+            if isinstance(json, Mapping) and isinstance(json["error"], str):
                 spacetrack_error_msg = json["error"]
         except (ValueError, KeyError, httpx2.ResponseNotRead):
             pass

--- a/tests/test_spacetrack.py
+++ b/tests/test_spacetrack.py
@@ -467,6 +467,21 @@ def test_raise_for_status(httpx2_mock):
     assert "Space-Track" not in str(exc.value)
 
 
+def test_raise_for_status_non_string_error(httpx2_mock):
+    httpx2_mock.add_response(
+        method="GET",
+        url="http://example.com/1",
+        status_code=400,
+        json={"error": 12345},
+    )
+
+    response = httpx2.get("http://example.com/1")
+
+    with pytest.raises(httpx2.HTTPStatusError) as exc:
+        _raise_for_status(response)
+    assert '{"error":12345}' in str(exc.value)
+
+
 def test_repr(httpx2_mock):
     with SpaceTrackClient("hello@example.com", "mypassword") as client:
         assert repr(client) == "SpaceTrackClient<identity='hello@example.com'>"


### PR DESCRIPTION
Only set the Space-Track error message from the JSON 'error' value when
it is a string; anything else falls back to showing the raw response
body. A truthy non-string value previously raised TypeError from the
message concatenation instead of the intended HTTPStatusError, so
callers catching HTTPStatusError missed the failure. No such response
has been observed from Space-Track; this is defensive hardening of the
error reporting path.
